### PR TITLE
Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,15 @@ var istanbulGlobal;
 var _originalSources = {};
 exports.originalSources = _originalSources;
 
+var filePrefixRExp;
+if (/^win/.test(process.platform)) {
+  // Windows adds the drive letter, so we must strip that too
+  filePrefixRExp = /file:\/\/\/\w:\//;
+} else {
+  filePrefixRExp = /file:\/\/\//;
+}
 function fromFileURL(url) {
-  if (url.substr(0, 7) == 'file:///')
-    return url.substr(6 + process.platform.match(/^win/));
-  return url;
+  return url.replace(filePrefixRExp);
 }
 
 exports.hookSystemJS = function(loader, exclude, coverageGlobal) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ exports.hookSystemJS = function(loader, exclude, coverageGlobal) {
     return loaderTranslate.apply(this, arguments)
     .then(function(source) {
       if (load.metadata.format == 'json' || load.metadata.format == 'defined' || load.metadata.loader && load.metadata.loaderModule.build === false)
-        return source;      
+        return source;
 
       // excludes
       if (exclude && exclude(load.address))
@@ -75,12 +75,20 @@ exports.hookSystemJS = function(loader, exclude, coverageGlobal) {
   loader.translate.coverageAttached = true;
 }
 
+function normalizeSourcePaths(sources) {
+  if (!sources) return sources;
+  Object.keys(sources).forEach(function (pathName) {
+    sources[path.normalize(pathName)] = sources[pathName];
+  });
+  return sources;
+}
+
 exports.remapCoverage = function(coverage, originalSources) {
   coverage = coverage || global[istanbulGlobal];
-  originalSources = originalSources || _originalSources;
+  originalSources = normalizeSourcePaths(originalSources || _originalSources);
   var collector = remapIstanbul(coverage, {
     readFile: function(name) {
-      return originalSources[name].source + 
+      return originalSources[name].source +
           (originalSources[name] && originalSources[name].sourceMap ? '\n//# sourceMappingURL=' + name.split('/').pop() + '.map' : '');
     },
     readJSON: function(name) {


### PR DESCRIPTION
Added a pass with path.normalize() to source hash. Files were addressed with forward slash, then accessed with a path using backslashes. This pass will not remove anything from the hash, only add copies of source objects with the windows path, and only on Windows.
